### PR TITLE
Feat/throwable error

### DIFF
--- a/src/aspi.spec.ts
+++ b/src/aspi.spec.ts
@@ -95,6 +95,32 @@ describe('JSON Response Suite', () => {
     });
   });
 
+  describe('Should work well with throwable and result type', async () => {
+    const response = await aspi.get('/todos/1').throwable().withResult().json<{
+      userId: number;
+      id: number;
+      title: string;
+      completed: boolean;
+    }>();
+
+    it('should yield a Result type when used withResult after throwable', () => {
+      expect(response).toHaveProperty('__tag');
+      expect(response).toHaveProperty('__tag', 'ok');
+    });
+
+    const resp = await aspi.get('/todos/1').withResult().throwable().json<{
+      userId: number;
+      id: number;
+      title: string;
+      completed: boolean;
+    }>();
+
+    it('should have todo object when throwable used after withResult', () => {
+      expect(resp.data).toBeDefined();
+      expect(resp.data).toHaveProperty('id', 1);
+    });
+  });
+
   describe('should get a todo - Schema validated', async () => {
     const [todo, todoError] = await aspi
       .get('/todos/1')

--- a/src/aspi.spec.ts
+++ b/src/aspi.spec.ts
@@ -77,6 +77,24 @@ describe('JSON Response Suite', () => {
     });
   });
 
+  describe('Should get a todo - Object', async () => {
+    const todoObject = await aspi.get('/todos/1').throwable().json<{
+      userId: number;
+      id: number;
+      title: string;
+      completed: boolean;
+    }>();
+
+    it('should yield an Ok (success)', () => {
+      expect(todoObject).toBeTruthy();
+    });
+
+    it('should have user id equal to 1', () => {
+      expect(todoObject.data).toBeDefined();
+      expect(todoObject.data).toHaveProperty('id', 1);
+    });
+  });
+
   describe('should get a todo - Schema validated', async () => {
     const [todo, todoError] = await aspi
       .get('/todos/1')
@@ -137,7 +155,7 @@ describe('JSON Response Suite', () => {
 
 describe('Error Suite', () => {
   const aspi = new Aspi({
-    baseUrl: 'https://httpstat.us/',
+    baseUrl: 'https://mock.httpstatus.io',
   });
 
   describe('Http Status code errors', () => {
@@ -312,7 +330,7 @@ describe('Schema Suite', () => {
 
 describe('Retry Suite', () => {
   const aspi = new Aspi({
-    baseUrl: 'https://httpstat.us/',
+    baseUrl: 'https://mock.httpstatus.io',
   });
 
   it('should retry 3 times', async () => {
@@ -321,7 +339,7 @@ describe('Retry Suite', () => {
       .get('/500')
       .setRetry({
         retries: 3,
-        retryOn: [500],
+        retryOn: [500, 413],
         onRetry: () => {
           count++;
         },

--- a/src/error.ts
+++ b/src/error.ts
@@ -120,3 +120,13 @@ export interface JSONParseError
       message: string;
     }
   > {}
+
+export const isAspiError = (error: unknown): error is AspiError<any> => {
+  return error instanceof AspiError;
+};
+
+export const isCustomError = (
+  error: unknown,
+): error is CustomError<any, any> => {
+  return error instanceof CustomError;
+};

--- a/src/error.ts
+++ b/src/error.ts
@@ -121,12 +121,14 @@ export interface JSONParseError
     }
   > {}
 
-export const isAspiError = (error: unknown): error is AspiError<any> => {
+export const isAspiError = <TReq extends AspiRequestInit>(
+  error: unknown,
+): error is AspiError<TReq> => {
   return error instanceof AspiError;
 };
 
-export const isCustomError = (
+export const isCustomError = <Tag extends string, A>(
   error: unknown,
-): error is CustomError<any, any> => {
+): error is CustomError<Tag, A> => {
   return error instanceof CustomError;
 };

--- a/src/request.ts
+++ b/src/request.ts
@@ -532,11 +532,15 @@ export class Request<
   throwable() {
     this.#shouldBeResult = false;
     this.#throwOnError = true;
+
+    // @ts-ignore
     return this as Request<
       Method,
       TRequest,
-      Prettify<
-        Opts & {
+      Merge<
+        Omit<Opts, 'withResult' | 'throwable'>,
+        {
+          withResult: false;
           throwable: true;
         }
       >
@@ -550,7 +554,8 @@ export class Request<
    * const request = new Request('/users', config);
    * const result = await request
    *   .setQueryParams({ id: '123' })
-   *   .withResult()
+   *   .
+   withResult()
    *   .notFound((error) => ({ message: 'User not found' }))
    *   .json<User>();
    *
@@ -747,9 +752,10 @@ export class Request<
       Method,
       TRequest,
       Merge<
-        Omit<Opts, 'withResult'>,
+        Omit<Opts, 'withResult' | 'throwable'>,
         {
           withResult: true;
+          throwable: false;
         }
       >
     >;
@@ -769,14 +775,6 @@ export class Request<
     } else {
       return [null, Result.getErrorOrNull(value)];
     }
-  }
-
-  async #makeUnSafeRequest<T>(
-    responseParser: (response: Response) => Promise<any>,
-    isJson: boolean = false,
-  ) {
-    const output = await this.#makeRequest<T>(responseParser, isJson);
-    return Result.getOrThrow(output);
   }
 
   async #makeRequest<T>(

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,20 @@
 import type { AspiRequest, AspiResponse } from './error';
 import type { HttpErrorCodes } from './http';
 
+// Utility types
+export type Prettify<Type> = Type extends Function
+  ? Type
+  : Extract<
+      {
+        [Key in keyof Type]: Type[Key];
+      },
+      Type
+    >;
+
+export type Merge<Object1, Object2> = Prettify<
+  Omit<Object1, keyof Object2> & Object2
+>;
+
 export type AspiConfigBase = {
   baseUrl: string;
   retryConfig?: AspiRetryConfig<AspiRequestInit>;
@@ -47,6 +61,7 @@ export type RequestOptions<TRequest extends AspiRequestInit> = {
   retryConfig?: AspiRetryConfig<TRequest>;
   middlewares?: Middleware<TRequest, TRequest>[];
   errorCbs?: ErrorCallbacks;
+  throwOnError?: boolean;
 };
 
 // Error Callbacks
@@ -63,3 +78,8 @@ export type AspiResultOk<TRequest extends AspiRequestInit, TData> = {
   request: AspiRequest<TRequest>;
   response: AspiResponse;
 };
+
+export type AspiPlainResponse<
+  TRequest extends AspiRequestInit,
+  TData,
+> = AspiResultOk<TRequest, TData>;


### PR DESCRIPTION
feat: Add `throwable` method to throw errors on non-successful responses

This commit introduces a new `throwable` method to both the `Aspi` and `Request` classes. This method enables users to configure their HTTP requests to throw an error immediately if the response status code indicates failure (e.g., 4xx or 5xx errors). Previously, errors were handled using the `Result` type, requiring users to explicitly check for errors. The `throwable` method simplifies error handling by throwing an `AspiError` when a non-successful response is received.

The `throwable` method removes the need to check the result. It offers a streamlined approach for scenarios where immediate error propagation is desired, enhancing code readability and reducing boilerplate. Additionally, this commit includes corresponding tests for the new `throwable` functionality, including tests for the Aspi class and a new "Object" test to ensure type safety when using `.json<Type>()`. Finally, the base URL for error and retry suites were changed to `mock.httpstatus.io` to provide reliability and prevent unintended calls to real services.