### PR TITLE
Fix: reformat test objects for lint compliance

### DIFF
--- a/src/tests/capability.spec.ts
+++ b/src/tests/capability.spec.ts
@@ -89,10 +89,16 @@ describe('Capability – composition', () => {
 
     fetchMock
       .mockResolvedValueOnce(
-        new Response('null', { status: 500, statusText: 'Internal Server Error' }),
+        new Response('null', {
+          status: 500,
+          statusText: 'Internal Server Error',
+        }),
       )
       .mockResolvedValueOnce(
-        new Response(JSON.stringify({ ok: true }), { status: 200, statusText: 'OK' }),
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          statusText: 'OK',
+        }),
       );
 
     const req = api.get('/users').useCapability(retryCap).withResult();
@@ -129,7 +135,11 @@ describe('Capability – composition', () => {
 describe('Capability – chaining', () => {
   it('useCapability returns the Request for fluent chaining', () => {
     const api = createApi();
-    const noop = () => ({ async run(runner: () => Promise<Response>) { return runner(); } });
+    const noop = () => ({
+      async run(runner: () => Promise<Response>) {
+        return runner();
+      },
+    });
 
     const req = api.get('/users').useCapability(noop).withResult();
     expect(req.isResult()).toBe(true);
@@ -148,7 +158,9 @@ describe('Capability – timeout', () => {
       () =>
         new Promise((_, reject) => {
           setTimeout(() => {
-            reject(new DOMException('The operation was aborted.', 'AbortError'));
+            reject(
+              new DOMException('The operation was aborted.', 'AbortError'),
+            );
           }, 100);
         }),
     );
@@ -189,7 +201,9 @@ describe('Capability – timeout', () => {
       () =>
         new Promise((_, reject) => {
           setTimeout(() => {
-            reject(new DOMException('The operation was aborted.', 'AbortError'));
+            reject(
+              new DOMException('The operation was aborted.', 'AbortError'),
+            );
           }, 100);
         }),
     );
@@ -214,7 +228,9 @@ describe('Capability – timeout', () => {
       () =>
         new Promise((_, reject) => {
           setTimeout(() => {
-            reject(new DOMException('The user aborted a request.', 'AbortError'));
+            reject(
+              new DOMException('The user aborted a request.', 'AbortError'),
+            );
           }, 200);
         }),
     );


### PR DESCRIPTION
Fix formatting inconsistencies in capability tests to satisfy linting rules and improve readability. The changes reformat `Response` constructors by spreading the options object over multiple lines, aligning each property (`status` and `statusText`) on its own line. The noop capability definition is expanded to a multi‑line object with an explicit `run` method block, making the intent clearer. All `reject` calls that create `DOMException` instances are similarly broken out, adding line breaks and a trailing comma to comply with the project's Prettier configuration and to prevent line‑length violations. These adjustments do not alter runtime behavior; they solely standardize code style across the test suite, eliminating warnings from the linter and ensuring the tests remain maintainable. This commit resolves the previous formatting-related lint failures that caused CI to flag the capability test files.